### PR TITLE
Use lining-nums throughout rather than old-style-nums

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -10,7 +10,7 @@ export const Button = ({ children, className, disabled, primary, ...rest }: any)
         <button
             disabled={disabled}
             {...rest}
-            className={`${className ?? ''} px-6 font-extrabold font-calluna tracking-tight text-sm uppercase border-2 ${style}`}
+            className={`${className ?? ''} px-6 font-extrabold font-calluna tracking-tight text-sm uppercase border-2 lining-nums ${style}`}
         >
             {children}
         </button>

--- a/client/src/components/H1.tsx
+++ b/client/src/components/H1.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const H1 = ({ children, className, ...rest }: any) => (
-    <h1 {...rest} className={(className ?? '') + ' border-b-2 py-4 mb-4 text-4xl leading-tight tracking-tight font-trajan font-semibold uppercase'}>
+    <h1 {...rest} className={(className ?? '') + ' border-b-2 py-4 mb-4 text-4xl leading-tight tracking-tight font-trajan font-semibold uppercase lining-nums'}>
         {children}
     </h1>
 )

--- a/client/src/components/H2.tsx
+++ b/client/src/components/H2.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const H2 = ({ children, className, ...rest }: any) => (
-    <h2 {...rest} className={(className ?? '') + ' border-b-2 py-2 mb-4 text-2xl leading-tight tracking-tight font-trajan uppercase'}>
+    <h2 {...rest} className={(className ?? '') + ' border-b-2 py-2 mb-4 text-2xl leading-tight tracking-tight font-trajan uppercase lining-nums'}>
         {children}
     </h2>
 )

--- a/client/src/components/H3.tsx
+++ b/client/src/components/H3.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const H3 = ({ children, className, ...rest }: any) => (
-    <h3 {...rest} className={(className ?? '') + ' border-b-2 mt-10 mb-4 pb-3 text-xl leading-tight tracking-tight font-trajan font-semibold uppercase text-teal'}>
+    <h3 {...rest} className={(className ?? '') + ' border-b-2 mt-10 mb-4 pb-3 text-xl leading-tight tracking-tight font-trajan font-semibold uppercase lining-nums text-teal'}>
         {children}
     </h3>
 )

--- a/client/src/components/H4.tsx
+++ b/client/src/components/H4.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const H4 = ({ children, className, ...rest }: any) => (
-    <h4 {...rest} className={(className ?? '') + ' mb-6 text-base leading-tight tracking-tight font-trajan font-bold uppercase'}>
+    <h4 {...rest} className={(className ?? '') + ' mb-6 text-base leading-tight tracking-tight font-trajan font-bold uppercase lining-nums'}>
         {children}
     </h4>
 )

--- a/client/src/components/SmallButton.tsx
+++ b/client/src/components/SmallButton.tsx
@@ -11,7 +11,7 @@ export const SmallButton = ({ children, collapseRight, className, selected, disa
     //const text = selected ? 'text-white' : ''
 
     return (
-        <button disabled={disabled} {...rest} className={`${className ?? ''} ${collapseRight ? '' : 'mr-3'} font-extrabold leading-none text-sm uppercase py-2 px-5 border-2 ${bg} ${border} ${!disabled && hover}`}>
+        <button disabled={disabled} {...rest} className={`${className ?? ''} ${collapseRight ? '' : 'mr-3'} font-extrabold leading-none text-sm uppercase py-2 px-5 border-2 lining-nums ${bg} ${border} ${!disabled && hover}`}>
             {children}
         </button>
     )

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,6 +8,7 @@
         @apply border-black;
         @apply font-calluna;
         @apply overflow-y-scroll;
+        @apply lining-nums;
         font-size: 20px;
         line-height: 30px;
     }


### PR DESCRIPTION
Set `font-variant-numeric` to `lining-nums`

Resolves #78

![image](https://user-images.githubusercontent.com/6231841/173043304-9560b553-9b0a-48da-9858-4dafc1b19ef3.png)
